### PR TITLE
Patch: Add "launchable" tag to metainfo file

### DIFF
--- a/org.zealdocs.Zeal.json
+++ b/org.zealdocs.Zeal.json
@@ -42,6 +42,10 @@
                 {
                     "type": "patch",
                     "path": "patches/capitalize-app-id.patch"
+                },
+                {
+                    "type": "patch",
+                    "path": "patches/metainfo-add-launchable-tag.patch"
                 }
             ]
         }

--- a/patches/metainfo-add-launchable-tag.patch
+++ b/patches/metainfo-add-launchable-tag.patch
@@ -1,0 +1,10 @@
+diff --git a/assets/freedesktop/org.zealdocs.zeal.appdata.xml.in b/assets/freedesktop/org.zealdocs.zeal.appdata.xml.in
+index 88abd54..b44068d 100644
+--- a/assets/freedesktop/org.zealdocs.zeal.appdata.xml.in
++++ b/assets/freedesktop/org.zealdocs.zeal.appdata.xml.in
+@@ -59,4 +59,5 @@
+     <content_attribute id="money-purchasing">none</content_attribute>
+     <content_attribute id="money-gambling">none</content_attribute>
+   </content_rating>
++  <launchable type="desktop-id">org.zealdocs.zeal.desktop</launchable>
+ </component>


### PR DESCRIPTION
Fixes a validation error in Flathub's linting step (`appstreamcli validate`):

```
$ flatpak run --command=flatpak-builder-lint org.flatpak.Builder --exceptions repo repo
{
    "errors": [
        "appstream-failed-validation"
    ],
    "appstream": [
        "E: org.zealdocs.Zeal:~: desktop-app-launchable-missing"
    ],
    "message": "Please consult the documentation at https://docs.flathub.org/docs/for-app-authors/linter"
}
```

This patch will be later incorporated in https://github.com/zealdocs/zeal/pull/1566