### PR TITLE
Update KDE runtime to 6.8

### DIFF
--- a/org.zealdocs.Zeal.json
+++ b/org.zealdocs.Zeal.json
@@ -1,10 +1,10 @@
 {
     "id": "org.zealdocs.Zeal",
     "runtime": "org.kde.Platform",
-    "runtime-version": "6.7",
+    "runtime-version": "6.8",
     "sdk": "org.kde.Sdk",
     "base": "io.qt.qtwebengine.BaseApp",
-    "base-version": "6.7",
+    "base-version": "6.8",
     "command": "zeal",
     "rename-appdata-file": "org.zealdocs.zeal.appdata.xml",
     "rename-desktop-file": "org.zealdocs.zeal.desktop",


### PR DESCRIPTION
Solves some font-rendering issue that I have.
I have built and tested this change locally.

- Operating System: TUXEDO OS (based on KDE Neon / Ubuntu 24.04 LTS)
- KDE Plasma Version: 6.2.3
- KDE Frameworks Version: 6.8.0
- Qt Version: 6.8.0
- Kernel Version: 6.11.0-107011-tuxedo (64-bit)
- Graphics Platform: Wayland
